### PR TITLE
fix some minors issues

### DIFF
--- a/app/a-propos/page.tsx
+++ b/app/a-propos/page.tsx
@@ -194,12 +194,12 @@ export default function AboutPage() {
             <Accordion
               title="Où j’ai travaillé ?"
               content={
-                <ul className="list-disc pl-4">
+                <ul className="list-disc pl-5 lg:pl-4">
                   <li className="mb-[37px] lg:mb-11">
                     <span className="antialiased font-GothamBook text-[12px] lg:text-[20px]">
                       TAMARA AGENCY - Experts Shopify
                     </span>
-                    <div className="mt-2 lg:mt-[23px] relative antialiased before:content-[''] before:h-[83px] before:md:h-[93px] before:w-[1px] before:bg-secondary before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2">
+                    <div className="mt-2 lg:mt-[23px] relative antialiased before:content-[''] before:h-[63px] before:md:h-[93px] before:w-[1px] before:bg-secondary before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2">
                       <div className="mb-[11px] font-GothamBook text-[10px] leading-[10.71px] lg:leading-[17px] lg:text-[16px] pl-3">
                         Alternance et freelance/2023
                       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,10 @@
     --background-start-rgb: 214, 219, 220;
     --background-end-rgb: 255, 255, 255;
   }
+
+  html {
+    height: 100%;
+  }
 }
 
 @layer aqua-custom-styles {


### PR DESCRIPTION
We are fixing some issues:
- scroll top after changing page: sometimes, when you tried to change page, you were stuck a the same position but in this new page.
- `height` of left line in `a-propos` page for mobile version _(see result below)_


**BEFORE**

![IMG_826B17E3B38F-1](https://github.com/maxime-carabina/aquastudio/assets/72019005/d439b22f-dbaf-4d2d-8068-e940a5130b4c)

**AFTER**
<img width="368" alt="Screenshot 2024-03-28 at 15 41 22" src="https://github.com/maxime-carabina/aquastudio/assets/72019005/a5a2c5f3-2321-42eb-bc18-57e0f79f43c5">
