### PR TITLE
remove html length in globals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,10 +28,6 @@
     --background-start-rgb: 214, 219, 220;
     --background-end-rgb: 255, 255, 255;
   }
-
-  html {
-    height: 100%;
-  }
 }
 
 @layer aqua-custom-styles {


### PR DESCRIPTION
We are removing `html: { height: 100% }` in `globals.css`.